### PR TITLE
StrAndUnicode removed in Django 1.8, use python_2_unicode_compatible

### DIFF
--- a/report_tools/reports.py
+++ b/report_tools/reports.py
@@ -2,8 +2,19 @@ from copy import deepcopy
 
 from django.db import models
 from django.utils.datastructures import SortedDict
-from django.utils.encoding import StrAndUnicode
 from django.utils.safestring import mark_safe
+from django.utils.encoding import force_text
+from django.utils.encoding import python_2_unicode_compatible
+
+try:
+    from django.utils.encoding import StrAndUnicode
+except ImportError:
+    from django.utils.encoding import python_2_unicode_compatible
+
+    @python_2_unicode_compatible
+    class StrAndUnicode(object):
+        def __str__(self):
+            return self.CodeType
 
 from .charts import Chart
 

--- a/report_tools/reports.py
+++ b/report_tools/reports.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
+from collections import OrderedDict
 
 from django.db import models
-from django.utils.datastructures import SortedDict
 from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text
 from django.utils.encoding import python_2_unicode_compatible
@@ -54,7 +54,7 @@ def get_declared_charts(bases, attrs, with_base_charts=True):
             if hasattr(base, 'declared_charts'):
                 charts = base.declared_charts.items() + charts
     
-    return SortedDict(charts)
+    return OrderedDict(charts)
 
 
 class DeclarativeChartsMetaclass(type):


### PR DESCRIPTION
As mentioned in #6 StrAndUnicode was deprecated in Django 1.5 (https://docs.djangoproject.com/en/1.8/releases/1.5/#deprecated-features-1-5) and has been removed in Django 1.8, which will be the new LTS release.

This pull-request implements the change suggested by @khrizo in #6 
